### PR TITLE
Change the config label to lowercase

### DIFF
--- a/src/MasterPassServiceProvider.php
+++ b/src/MasterPassServiceProvider.php
@@ -20,7 +20,7 @@ class MasterPassServiceProvider extends ServiceProvider
     {
         $this->registerAuthProviders();
 
-        $this->mergeConfigFrom(__DIR__.'/config/master_password.php', 'MASTER_PASSWORD');
+        $this->mergeConfigFrom(__DIR__.'/config/master_password.php', 'master_password');
         if (config('master_password.MASTER_PASSWORD')) {
             $this->changeUsersDriver();
         }


### PR DESCRIPTION
With the settings label in uppercase, the service did not work (unless you used a custom settings file in the project `config/` folder).

The label should match the name of the config file, not with the parameter label.