### PR TITLE
fix Method Illuminate\Auth\RequestGuard::isLoggedInByMasterPass does not exist

### DIFF
--- a/src/MasterPassServiceProvider.php
+++ b/src/MasterPassServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Imanghafoori\MasterPass;
 
 use Illuminate\Auth\Events\Logout;
-use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
@@ -76,7 +76,7 @@ class MasterPassServiceProvider extends ServiceProvider
     private function defineIsUsingMasterPass()
     {
         foreach (array_keys(config('auth.guards')) as $guard) {
-            if (($authGuard = Auth::guard($guard)) instanceof StatefulGuard) {
+            if (($authGuard = Auth::guard($guard)) instanceof Guard) {
                 $authGuard->macro('isLoggedInByMasterPass', function () {
                     return session(config('master_password.session_key'), false);
                 });


### PR DESCRIPTION
As soon as project uses Jetstream + Inertia there is an error
`Method Illuminate\Auth\RequestGuard::isLoggedInByMasterPass does not exist.` in Laravel 10. 
Bug was detected in middleware.
 
`RequestGuard` implements `Guard`. Not `StatefulGuard`.

Was tested on `Laravel Framework 10.14.1` and `PHP 8.1.20` 